### PR TITLE
Fix placeholders being lost upon using /papi reload

### DIFF
--- a/src/main/java/me/realized/tokenmanager/hook/hooks/PlaceholderHook.java
+++ b/src/main/java/me/realized/tokenmanager/hook/hooks/PlaceholderHook.java
@@ -35,6 +35,11 @@ public class PlaceholderHook extends PluginHook<TokenManagerPlugin> {
         }
 
         @Override
+        public boolean persist() {
+            return true;
+        }
+
+        @Override
         public String onPlaceholderRequest(final Player player, final String identifier) {
             return plugin.handlePlaceholderRequest(player, identifier);
         }


### PR DESCRIPTION
Someone else brought to my attention that placeholders would return %tm_tokens% instead of the balance randomly.

The reason for that is that if you use an internal class to register placeholders, you have to tell PlaceholderAPI that your placeholders should not be unloaded upon calling /papi reload.

Before:
![image](https://user-images.githubusercontent.com/60011425/87871876-8623a280-c9b4-11ea-8d50-254f8e8c276e.png)

After:
![javaw_2020_07_19_11_31_46](https://user-images.githubusercontent.com/60011425/87871885-976caf00-c9b4-11ea-874e-25eec9a9b6f7.png)
